### PR TITLE
155: Optimize lay-out on producing process page

### DIFF
--- a/resources/views/pages/producing/activity.blade.php
+++ b/resources/views/pages/producing/activity.blade.php
@@ -252,12 +252,18 @@ use App\ResourcePerson;
                                                        data-toggle="tooltip" data-placement="bottom"
                                                        title="{{ trans('tooltips.producing_status') }}"></i>
                     </h4>
-                    <label><input type="radio" name="status" value="1"
-                                  checked/><span>{{ __('activity.finished') }}</span></label>
-                    <label><input type="radio" name="status"
-                                  value="2"/><span>{{ __('activity.busy') }}</span></label>
-                    <label><input type="radio" name="status"
-                                  value="3"/><span>{{ __('activity.transfered') }}</span></label>
+                    <div id="finishedcontainer">
+                        <label><input type="radio" name="status" value="1"
+                                     checked/><span>{{ __('activity.finished') }}</span></label>
+                    </div>
+                    <div id="busycontainer">
+                        <label><input type="radio" name="status"
+                                    value="2"/><span>{{ __('activity.busy') }}</span></label>
+                    </div>
+                    <div id="transferedcontainer">
+                        <label><input type="radio" name="status"
+                                    value="3"/><span>{{ __('activity.transfered') }}</span></label>
+                    </div>
                     <div class="clearfix"></div>
                 </div>
             </div>
@@ -268,12 +274,18 @@ use App\ResourcePerson;
                                                            data-toggle="tooltip" data-placement="bottom"
                                                            title="{{ trans('tooltips.producing_difficulty') }}"></i>
                     </h4>
-                    <label><input type="radio" name="moeilijkheid" value="1"
+                    <div id="easycontainer"> 
+                        <label><input type="radio" name="moeilijkheid" value="1"
                                   checked/><span>{{ __('activity.easy') }}</span></label>
-                    <label><input type="radio" name="moeilijkheid"
-                                  value="2"/><span>{{ __('activity.average') }}</span></label>
-                    <label><input type="radio" name="moeilijkheid"
+                    </div>
+                    <div id="averageontainer">
+                        <label><input type="radio" name="moeilijkheid"
+                                    value="2"/><span>{{ __('activity.average') }}</span></label>
+                    </div>
+                    <div id="hardcontainer">
+                        <label><input type="radio" name="moeilijkheid"
                                   value="3"/><span>{{ __('activity.hard') }}</span></label>
+                    </div>
                     <div class="clearfix"></div>
                 </div>
             </div>


### PR DESCRIPTION
#155 
Problem: 
the lay-out for the list of Status and Difficulty is not optimal. Should be 3 items in a vertical row, below each other and not one of them on the side.

Fix:
Set div's between the buttons. Now they are in a vertical row. 