### PR TITLE
Fix for notifications

### DIFF
--- a/app/Notifications/StudentDigestSender.php
+++ b/app/Notifications/StudentDigestSender.php
@@ -35,7 +35,7 @@ class StudentDigestSender
         // }
         
         // Instead of checking if the notification is usable, use the original notification.
-        $this->mailer->to($user->email)->send(new StudentDigest($user, $usableNotifications));
+        $this->mailer->to($user->email)->send(new StudentDigest($user, $notifications));
         foreach ($notifications as $notification) {
             $notification->markAsRead();
         }

--- a/app/Notifications/StudentDigestSender.php
+++ b/app/Notifications/StudentDigestSender.php
@@ -25,14 +25,19 @@ class StudentDigestSender
     public function sendNotifications(array $notifications, Student $user): void
     {
 
-        $usableNotifications = array_filter($notifications, function (DatabaseNotification $notification) {
-            return $notification->type === FolderFeedbackGiven::class;
-        });
-
+        // Disable function usableNotifications because it fails. Not sure why it is needed!
+        // $usableNotifications = array_filter($notifications, function (DatabaseNotification $notification) {
+        //     return $notification->type === FolderFeedbackGiven::class;
+        // });
+        
+        // foreach ($usableNotifications as $notification) {
+        //     $notification->markAsRead();
+        // }
+        
+        // Instead of checking if the notification is usable, use the original notification.
         $this->mailer->to($user->email)->send(new StudentDigest($user, $usableNotifications));
-
-        foreach ($usableNotifications as $notification) {
+        foreach ($notifications as $notification) {
             $notification->markAsRead();
         }
-    }
-}
+
+    }}

--- a/app/Notifications/TeacherDigestSender.php
+++ b/app/Notifications/TeacherDigestSender.php
@@ -25,13 +25,17 @@ class TeacherDigestSender
     public function sendNotifications(array $notifications, Student $user): void
     {
 
-        $usableNotifications = array_filter($notifications, function (DatabaseNotification $notification) {
-            return $notification->type === FolderSharedWithTeacher::class;
-        });
+        // $usableNotifications = array_filter($notifications, function (DatabaseNotification $notification) {
+        //     return $notification->type === FolderSharedWithTeacher::class;
+        // });
 
-        $this->mailer->to($user->email)->send(new TeacherDigest($user, $usableNotifications));
+        // foreach ($usableNotifications as $notification) {
+        //     $notification->markAsRead();
+        // }
 
-        foreach ($usableNotifications as $notification) {
+        $this->mailer->to($user->email)->send(new TeacherDigest($user, $notifications));
+
+        foreach ($notifications as $notification) {
             $notification->markAsRead();
         }
     }

--- a/app/Notifications/TeacherInactiveStudentSender.php
+++ b/app/Notifications/TeacherInactiveStudentSender.php
@@ -25,13 +25,16 @@ class TeacherInactiveStudentSender
      */
     public function sendNotifications(array $notifications, Student $teacher): void
     {
-        $usableNotifications = array_filter($notifications, static function (DatabaseNotification $notification) {
-            return $notification->type === NoActivityOfStudent::class;
-        });
+        // $usableNotifications = array_filter($notifications, static function (DatabaseNotification $notification) {
+        //     return $notification->type === NoActivityOfStudent::class;
+        // });
+        // foreach ($usableNotifications as $notification) {
+        //     $notification->markAsRead();
+        // }
 
-        $this->mailer->to($teacher->email)->send(new InactiveStudent($teacher, $usableNotifications));
+        $this->mailer->to($teacher->email)->send(new InactiveStudent($teacher, $notifications));
 
-        foreach ($usableNotifications as $notification) {
+        foreach ($notifications as $notification) {
             $notification->markAsRead();
         }
     }


### PR DESCRIPTION
The function checking for usableNotifications returned an empty array. Changed this to use the original notifications array which resulted in a notification mail with a notification and the notification set as read.

Made these adjustments for Students and Teachers